### PR TITLE
[#5] 추천시스템 내의 예외처리 구현

### DIFF
--- a/recommend_model/app/adapters/chroma_adapter.py
+++ b/recommend_model/app/adapters/chroma_adapter.py
@@ -1,6 +1,7 @@
 #FastAPI와 Docker ChromaDB 서버 사이의 연결 어댑터
 
 import chromadb
+from ..exception.errors import ChromaQueryError
 
 class ChromaAdapter:
     def __init__(self, host: str, port: int):
@@ -14,9 +15,12 @@ class ChromaAdapter:
 
     # 벡터 검색 query(핵심 메서드)
     def query(self, collection_name: str, query_embedding: list, n_results: int, where: dict | None = None):
-        col = self.get_collection(collection_name)
-        return col.query(
-            query_embeddings=[query_embedding], # 검색할 임베딩 (512차원)
-            n_results=n_results, # 상위 N개 결과 ex) n_results: 4  # 상위 4개 추천
-            where=where, # 메타데이터 필터 ex) where: {"category": "TOP"}  # TOP 카테고리만 검색
-        )
+        try:
+            col = self.get_collection(collection_name)
+            return col.query(
+                query_embeddings=[query_embedding],
+                n_results=n_results,
+                where=where,
+            )
+        except Exception as e:
+            raise ChromaQueryError(collection=collection_name, reason=str(e)) from e

--- a/recommend_model/app/adapters/s3_adapter.py
+++ b/recommend_model/app/adapters/s3_adapter.py
@@ -8,6 +8,10 @@ import boto3
 from botocore.exceptions import ClientError
 from botocore.config import Config
 
+from ..exception.errors import (
+    S3KeyNotFound, S3FetchError
+)
+
 logger = logging.getLogger(__name__)
 
 class S3Adapter:
@@ -26,12 +30,18 @@ class S3Adapter:
             aws_secret_access_key=aws_secret_access_key, endpoint_url=endpoint_url,
             config=Config(connect_timeout=5, read_timeout=30, retries={"max_attempts": 3}),
         )
-        self._client.list_buckets()  # 연결 테스트
 
     #S3 객체를 바이트로 다운로드
     def get_bytes(self, key: str) -> bytes:
-        resp = self._client.get_object(Bucket=self.bucket_name, Key=key)
-        return resp["Body"].read()
+        try:
+            resp = self._client.get_object(Bucket=self.bucket_name, Key=key)
+            return resp["Body"].read()
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code == "NoSuchKey":
+                raise S3KeyNotFound(key)
+            else:
+                raise S3FetchError(key, str(e))
 
     # S3 JSON 파일을 Python dict로 파싱
     def get_json(self, key: str) -> dict[str, Any]:

--- a/recommend_model/app/api/v2/endpoints/recommend.py
+++ b/recommend_model/app/api/v2/endpoints/recommend.py
@@ -1,7 +1,7 @@
 from typing import List
 from fastapi import APIRouter, Depends, Request
-from app.schemas.recschema import RecommendRequest, RecommendResponse
-from app.services.recommend_service import RecommendService
+from ....schemas.recschema import RecommendRequest, RecommendResponse
+from ....services.recommend_service import RecommendService
 
 router = APIRouter()
 

--- a/recommend_model/app/exception/custom.py
+++ b/recommend_model/app/exception/custom.py
@@ -1,0 +1,45 @@
+# 커스텀 예외 정의
+from app.exception.errors import AppError
+
+
+# image url이 파싱이 불가능하거나 문제가 있을 때 사용되는 메서드
+class InvalidImageUrl(AppError):
+    def __init__(self, image_url: str):
+        super().__init__(
+            code="INVALID_IMAGE_URL",
+            status_code=400,
+            message="image_url must start with s3://",
+            detail={"image_url": image_url},
+        )
+
+# category가 TOP/PANTS 등 지원 목록에 없을 때 사용하는 메서드
+class UnsupportedCategory(AppError):
+    def __init__(self, category: str):
+        super().__init__(
+            code="UNSUPPORTED_CATEGORY",
+            status_code=400,
+            message="Unsupported category.",
+            detail={"category": category},
+        )
+
+
+# S3에서 해당 key의 이미지/JSON이 없을 때 사용하는 메서드
+class S3KeyNotFound(AppError):
+    def __init__(self, key: str):
+        super().__init__(
+            code="S3_KEY_NOT_FOUND",
+            status_code=404,
+            message="S3 object not found.",
+            detail={"key": key},
+        )
+
+
+#ChromaDB 쿼리 호출 자체가 실패했을 때 사용하는 메서드
+class ChromaQueryError(AppError):
+    def __init__(self, collection: str, reason: str):
+        super().__init__(
+            code="CHROMA_QUERY_ERROR",
+            status_code=502,
+            message="Vector DB query failed.",
+            detail={"collection": collection, "reason": reason},
+        )

--- a/recommend_model/app/exception/custom.py
+++ b/recommend_model/app/exception/custom.py
@@ -1,45 +1,45 @@
-# 커스텀 예외 정의
-from app.exception.errors import AppError
+# # 커스텀 예외 정의
+# from app.exception.errors import AppError
 
 
-# image url이 파싱이 불가능하거나 문제가 있을 때 사용되는 메서드
-class InvalidImageUrl(AppError):
-    def __init__(self, image_url: str):
-        super().__init__(
-            code="INVALID_IMAGE_URL",
-            status_code=400,
-            message="image_url must start with s3://",
-            detail={"image_url": image_url},
-        )
+# # image url이 파싱이 불가능하거나 문제가 있을 때 사용되는 메서드
+# class InvalidImageUrl(AppError):
+#     def __init__(self, image_url: str):
+#         super().__init__(
+#             code="INVALID_IMAGE_URL",
+#             status_code=400,
+#             message="image_url must start with s3://",
+#             detail={"image_url": image_url},
+#         )
 
-# category가 TOP/PANTS 등 지원 목록에 없을 때 사용하는 메서드
-class UnsupportedCategory(AppError):
-    def __init__(self, category: str):
-        super().__init__(
-            code="UNSUPPORTED_CATEGORY",
-            status_code=400,
-            message="Unsupported category.",
-            detail={"category": category},
-        )
-
-
-# S3에서 해당 key의 이미지/JSON이 없을 때 사용하는 메서드
-class S3KeyNotFound(AppError):
-    def __init__(self, key: str):
-        super().__init__(
-            code="S3_KEY_NOT_FOUND",
-            status_code=404,
-            message="S3 object not found.",
-            detail={"key": key},
-        )
+# # category가 TOP/PANTS 지원 목록에 없을 때 사용하는 메서드
+# class UnsupportedCategory(AppError):
+#     def __init__(self, category: str):
+#         super().__init__(
+#             code="UNSUPPORTED_CATEGORY",
+#             status_code=400,
+#             message="Unsupported category.",
+#             detail={"category": category},
+#         )
 
 
-#ChromaDB 쿼리 호출 자체가 실패했을 때 사용하는 메서드
-class ChromaQueryError(AppError):
-    def __init__(self, collection: str, reason: str):
-        super().__init__(
-            code="CHROMA_QUERY_ERROR",
-            status_code=502,
-            message="Vector DB query failed.",
-            detail={"collection": collection, "reason": reason},
-        )
+# # S3에서 해당 key의 이미지/JSON이 없을 때 사용하는 메서드
+# class S3KeyNotFound(AppError):
+#     def __init__(self, key: str):
+#         super().__init__(
+#             code="S3_KEY_NOT_FOUND",
+#             status_code=404,
+#             message="S3 object not found.",
+#             detail={"key": key},
+#         )
+
+
+# #ChromaDB 쿼리 호출 자체가 실패했을 때 사용하는 메서드
+# class ChromaQueryError(AppError):
+#     def __init__(self, collection: str, reason: str):
+#         super().__init__(
+#             code="CHROMA_QUERY_ERROR",
+#             status_code=502,
+#             message="Vector DB query failed.",
+#             detail={"collection": collection, "reason": reason},
+#         )

--- a/recommend_model/app/exception/errors.py
+++ b/recommend_model/app/exception/errors.py
@@ -1,0 +1,41 @@
+# app/errors.py  (원하면 main.py에 같이 둬도 됨)
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+@dataclass
+class AppError(Exception):
+    code: str
+    status_code: int
+    message: str
+    detail: Optional[Dict[str, Any]] = None
+
+
+class InvalidImageUrl(AppError):
+    def __init__(self, image_url: str):
+        super().__init__("INVALID_IMAGE_URL", 400, "image_url must start with s3://", {"image_url": image_url})
+
+class InvalidTopK(AppError):
+    def __init__(self, topk: int):
+        super().__init__("INVALID_TOPK", 400, "topk must be between 1 and 50.", {"topk": topk})
+
+class S3KeyNotFound(AppError):
+    def __init__(self, key: str):
+        super().__init__("S3_KEY_NOT_FOUND", 404, "S3 object not found.", {"key": key})
+
+class S3AccessDenied(AppError):
+    def __init__(self, key: str):
+        super().__init__("S3_ACCESS_DENIED", 403, "S3 access denied.", {"key": key})
+
+class S3FetchError(AppError):
+    def __init__(self, key: str, reason: str):
+        super().__init__("S3_FETCH_ERROR", 502, "Failed to fetch object from S3.", {"key": key, "reason": reason})
+
+class PipelineError(AppError):
+    def __init__(self, reason: str):
+        super().__init__("PIPELINE_ERROR", 503, "Failed to run image pipeline.", {"reason": reason})
+
+class ChromaQueryError(AppError):
+    def __init__(self, collection: str, reason: str):
+        super().__init__("CHROMA_QUERY_ERROR", 502, "Vector DB query failed.", {"collection": collection, "reason": reason})

--- a/recommend_model/app/exception/errors.py
+++ b/recommend_model/app/exception/errors.py
@@ -16,17 +16,13 @@ class InvalidImageUrl(AppError):
     def __init__(self, image_url: str):
         super().__init__("INVALID_IMAGE_URL", 400, "image_url must start with s3://", {"image_url": image_url})
 
-class InvalidTopK(AppError):
-    def __init__(self, topk: int):
-        super().__init__("INVALID_TOPK", 400, "topk must be between 1 and 50.", {"topk": topk})
-
+class UnsupportedCategory(AppError):
+    def __init__(self, category: str):
+        super().__init__("UNSUPPORTED_CATEGORY", 400, "Unsupported category.", {"category": category})
+    
 class S3KeyNotFound(AppError):
     def __init__(self, key: str):
         super().__init__("S3_KEY_NOT_FOUND", 404, "S3 object not found.", {"key": key})
-
-class S3AccessDenied(AppError):
-    def __init__(self, key: str):
-        super().__init__("S3_ACCESS_DENIED", 403, "S3 access denied.", {"key": key})
 
 class S3FetchError(AppError):
     def __init__(self, key: str, reason: str):

--- a/recommend_model/app/exception/handlers.py
+++ b/recommend_model/app/exception/handlers.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from .errors import AppError
+
+
+def install_exception_handlers(app: FastAPI) -> None:
+
+    # 서비스 로직에서 raise AppError(...) 또는 raise InvalidImageUrl(...)를 던지면, FastAPI가 호출하는 핸들러
+    @app.exception_handler(AppError)
+    async def app_error_handler(request: Request, exc: AppError):
+        return JSONResponse(
+            status_code=exc.status_code, # HTTP 상태코드
+            content={"error": {"code": exc.code, "message": exc.message, "detail": exc.detail or {}}},
+        )
+
+
+    """
+    검토할 메서드 2개 -> PR 참고
+    """
+    # FastAPI/Starlette 내부에서 발생하는 HTTPException을 잡는 핸들러
+    # ex) 404 Not Found, 401 Unauthorized 등
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error": {"code": "HTTP_EXCEPTION", "message": exc.detail, "detail": {}}},
+        )
+
+    # 클라이언트가 요청 바디/쿼리/경로 파라미터를 잘못 보내서 Pydantic 검증이 실패할 때 FastAPI가 호출하는 핸들러
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError):
+        return JSONResponse(
+            status_code=422,
+            content={"error": {"code": "VALIDATION_ERROR", "message": "Invalid request.", "detail": {"errors": exc.errors()}}},
+        )

--- a/recommend_model/app/exception/handlers.py
+++ b/recommend_model/app/exception/handlers.py
@@ -3,8 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from .errors import AppError
-
+from .errors import AppError, UnsupportedCategory,S3KeyNotFound, S3FetchError, PipelineError, ChromaQueryError
 
 def install_exception_handlers(app: FastAPI) -> None:
 
@@ -35,4 +34,56 @@ def install_exception_handlers(app: FastAPI) -> None:
         return JSONResponse(
             status_code=422,
             content={"error": {"code": "VALIDATION_ERROR", "message": "Invalid request.", "detail": {"errors": exc.errors()}}},
+        )
+    
+    # UnsupportedCategory 관련 핸들러
+    @app.exception_handler(UnsupportedCategory)
+    async def unsupported_category_handler(request: Request, exc: UnsupportedCategory):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error": {
+                "code": exc.code,
+                "message": exc.message,
+                "detail": exc.detail
+            }}
+        )
+    
+
+    #S3KeyNotFound 관련 핸들러
+    @app.exception_handler(S3KeyNotFound)
+    async def s3_key_not_found_handler(request: Request, exc: S3KeyNotFound):
+        return JSONResponse(
+            status_code=exc.status_code,  # 404
+            content={"error": {
+                "code": exc.code,           # "S3_KEY_NOT_FOUND"
+                "message": exc.message,     # "S3 object not found."
+                "detail": exc.detail        # {"key": "image/fake.jpg"}
+            }}
+        )
+
+    @app.exception_handler(S3FetchError)
+    async def s3_fetch_error_handler(request: Request, exc: S3FetchError):
+        return JSONResponse(
+            status_code=502,  # 또는 500
+            content={"error": {"code": exc.code, "message": exc.message, "detail": exc.detail}},
+        )
+
+    @app.exception_handler(PipelineError)
+    async def pipeline_error_handler(request: Request, exc: PipelineError):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={
+                "error": {
+                    "code": exc.code,
+                    "message": exc.message,
+                    "detail": exc.detail or {}
+                }
+            },
+        )
+    
+    @app.exception_handler(ChromaQueryError)
+    async def chroma_query_error_handler(request: Request, exc: ChromaQueryError):
+        return JSONResponse(
+            status_code=exc.status_code,  # 너는 502로 정의함
+            content={"error": {"code": exc.code, "message": exc.message, "detail": exc.detail or {}}},
         )

--- a/recommend_model/app/main.py
+++ b/recommend_model/app/main.py
@@ -8,7 +8,11 @@ from .api.v2.routers import api_router
 from .models_runtime.yolos import YolosRuntime
 from .models_runtime.fashionclip import FashionClipRuntime
 
+from .exception.handlers import install_exception_handlers
+
 app = FastAPI(title="Recommendation API")
+
+install_exception_handlers(app)
 app.include_router(api_router, prefix="/v2")
 
 @asynccontextmanager
@@ -22,8 +26,8 @@ async def lifespan(app: FastAPI):
     )
     
 
-    # 2) S3 init (추가)
-    bucket = os.environ["AWS_S3_BUCKET_NAME"]  # 없으면 여기서 KeyError로 바로 터짐
+    # 2) S3 init
+    bucket = os.environ["AWS_S3_BUCKET_NAME"]
     region = os.getenv("AWS_DEFAULT_REGION", "ap-northeast-2")
     endpoint_url = os.getenv("S3_ENDPOINT_URL")
 

--- a/recommend_model/app/services/pipeline.py
+++ b/recommend_model/app/services/pipeline.py
@@ -8,6 +8,9 @@ from PIL import Image
 from io import BytesIO
 from typing import Optional, Dict, Any
 
+from PIL import UnidentifiedImageError
+from ..exception.errors import PipelineError
+
 # -----------------------
 # Constants
 # -----------------------
@@ -178,18 +181,22 @@ def run_pipeline_from_bytes(
     bytes -> PIL -> YOLOS crop(1개) -> FashionCLIP embedding
     (S3/Chroma 접근 없음)
     """
-    image = load_image_from_bytes(img_bytes)
-
-    crop_item = detect_one_crop(
+    try:
+        image = load_image_from_bytes(img_bytes)
+        crop_item = detect_one_crop(
         image=image,
         yolos_rt=yolos_rt,
         score_thresh=score_thresh,
         category=category,
-    )
-    if crop_item is None:
-        return None
-
-    return embed_one_crop(crop_item=crop_item, fclip_rt=fclip_rt, l2_normalize=True)
+        )
+        if crop_item is None:
+            raise PipelineError("No detection found")
+        return embed_one_crop(crop_item=crop_item, fclip_rt=fclip_rt, l2_normalize=True)
+    except UnidentifiedImageError as e:
+        raise PipelineError(f"Invalid image bytes: {e}") from e
+    except Exception as e:
+        raise PipelineError(str(e)) from e
+    
 #여기서 가장 느린 부분은 모델 추론(특히 GPU 없으면 더 느림)과 S3 다운로드입니다.
 
 #동기 처리로 운영하면 동시 요청이 많을 때 병목이 생길 수 있으니, 

--- a/recommend_model/app/services/recommend_service.py
+++ b/recommend_model/app/services/recommend_service.py
@@ -10,8 +10,8 @@ from ..schemas.recschema import RecommendRequest, RecommendResponse
 from botocore.exceptions import ClientError
 
 from ..exception.errors import (
-    InvalidImageUrl, InvalidTopK,
-    S3KeyNotFound, S3AccessDenied, S3FetchError,
+    InvalidImageUrl, UnsupportedCategory,
+    S3KeyNotFound, S3FetchError,
     PipelineError, ChromaQueryError,
 )
 
@@ -60,17 +60,14 @@ class RecommendService:
             code = _aws_error_code(e)
             if code in ("NoSuchKey", "404", "NotFound"):
                 raise S3KeyNotFound(key)
-            if code in ("AccessDenied", "403"):
-                raise S3AccessDenied(key)
             raise S3FetchError(key, reason=f"ClientError:{code}")
         except Exception as e:
             raise S3FetchError(key, reason=repr(e))
 
     def recommend(self, image_url: str, category: str, topk: int = 4) -> Dict[str, Any]:
 
-        if not isinstance(topk, int) or topk <= 0 or topk > 50:
-            raise InvalidTopK(topk)
-        
+        if category.upper() not in ["TOP", "PANTS"]:
+            raise UnsupportedCategory(category)
         # 1) S3 URL 파싱
         img_key = self._s3_url_to_key(image_url)
         img_bytes = self.s3.get_bytes(img_key)

--- a/recommend_model/app/services/recommend_service.py
+++ b/recommend_model/app/services/recommend_service.py
@@ -2,14 +2,27 @@
 from typing import Dict, Any, List
 from pathlib import Path
 from urllib.parse import urlparse
-
+import logging
 from .pipeline import run_pipeline_from_bytes
 from ..adapters.chroma_adapter import ChromaAdapter
 from ..adapters.s3_adapter import S3Adapter
-from app.schemas.recschema import RecommendRequest, RecommendResponse
+from ..schemas.recschema import RecommendRequest, RecommendResponse
+from botocore.exceptions import ClientError
+
+from ..exception.errors import (
+    InvalidImageUrl, InvalidTopK,
+    S3KeyNotFound, S3AccessDenied, S3FetchError,
+    PipelineError, ChromaQueryError,
+)
 
 # TOP/PANTS 요청 시 어떤 ChromaDB 컬렉션을 쓸지 결정
 COLLECTION_MAP = {"TOP": "fashion_items", "PANTS": "fashion_items_pants"}
+
+logger = logging.getLogger("uvicorn.error")
+
+
+def _aws_error_code(e: ClientError) -> str:
+    return str(e.response.get("Error", {}).get("Code", ""))
 
 
 class RecommendService:
@@ -26,7 +39,7 @@ class RecommendService:
         s3://bucket/label_data/TOP/img.jpg -> label_data/TOP/img.jpg
         """
         if not s3_url.startswith("s3://"):
-            raise ValueError(f"image_url must be s3://... got={s3_url}")
+            raise InvalidImageUrl(f"image_url must be s3://... got={s3_url}")
         u = urlparse(s3_url)
         return u.path.lstrip("/")
 
@@ -39,35 +52,58 @@ class RecommendService:
 
     def get_collection_name(self, category: str) -> str:
         return COLLECTION_MAP.get(category.upper(), "fashion_items")
+    
+    def _get_s3_bytes(self, key: str) -> bytes:
+        try:
+            return self.s3.get_bytes(key)
+        except ClientError as e:
+            code = _aws_error_code(e)
+            if code in ("NoSuchKey", "404", "NotFound"):
+                raise S3KeyNotFound(key)
+            if code in ("AccessDenied", "403"):
+                raise S3AccessDenied(key)
+            raise S3FetchError(key, reason=f"ClientError:{code}")
+        except Exception as e:
+            raise S3FetchError(key, reason=repr(e))
 
     def recommend(self, image_url: str, category: str, topk: int = 4) -> Dict[str, Any]:
+
+        if not isinstance(topk, int) or topk <= 0 or topk > 50:
+            raise InvalidTopK(topk)
+        
         # 1) S3 URL 파싱
         img_key = self._s3_url_to_key(image_url)
         img_bytes = self.s3.get_bytes(img_key)
         query_stem = self._filename_stem_from_s3_url(image_url)
 
         # 2) 파이프라인: crop → embedding
-        out = run_pipeline_from_bytes(
-            img_bytes=img_bytes,
-            category=category,
-            yolos_rt=self.yolos_rt,
-            fclip_rt=self.fclip_rt,
-            score_thresh=0.3,
-        )
+        try:
+            out = run_pipeline_from_bytes(
+                img_bytes=img_bytes,
+                category=category,
+                yolos_rt=self.yolos_rt,
+                fclip_rt=self.fclip_rt,
+                score_thresh=0.3,
+            )
+        except Exception as e:
+            raise PipelineError(reason=repr(e))
+        
         if out is None:
-            return {
-                "query": {"image_url": image_url, "category": category.upper()},
-                "product_ids": [],
-            }
+            return {"query": {"image_url": image_url, "category": category.upper()}, "product_ids": []}
 
         # 3) Chroma 검색
         col_name = self.get_collection_name(category)
-        results = self.chroma.query(
-            collection_name=col_name,
-            query_embedding=out["embedding"].numpy().tolist(),
-            n_results=topk + 1, # topk+1 (자기자신 제외용)
-            where={"category": category.upper()}, # 카테고리 필터링
-        )
+
+        try:
+            results = self.chroma.query(
+                collection_name=col_name,
+                query_embedding=out["embedding"].numpy().tolist(),
+                n_results=topk + 1, # topk+1 (자기자신 제외용)
+                where={"category": category.upper()}, # 카테고리 필터링
+            )
+        except Exception as e:
+            raise ChromaQueryError(collection=col_name, reason=repr(e))
+        
         metadatas = (results.get("metadatas") or [[]])[0] or []
 
         # 4) product_id 추출


### PR DESCRIPTION
세부적인 작업
- 추천시스템 내에서 발생할 수 있는 예외처리 구현
- 중복되는 파일이나 불필요한 기능들 제거


게이트웨이 담당자분께서 확인해주셔야 할 부분
- handler 부분(http_exception_handler,validation_exception_handler) 에서 예외처리 메시지 구조를 하나로 통일함
- 통일한 이유는 게이트웨이가 예외 처리를 단순/자동화하도록 해주기 위해서 진행하였음.
- 하지만 원래 게이트웨이가 파싱/분기하는 규격을 먼저 정해두고 그 규격에 맞춰서 해야하는 것이기 때문에 게이트웨이에서 오류를 호출/처리하는 방식이 무엇인지에 대한 답변이 필요함. -> 그에 맞춰서 핸들러 부분을 다시 수정할 예정.

할 수 있는 질문

- AccessDenied 뺀 이유: 이미 S3 키가 잘못된 경우에 에러가 뜨도록 코드에 구현이 되어있음.

- self._client.list_buckets() 을 뺀 이유
기존의 로직: list_buckets()가 startup에서 실행되는 구조라서 “유효하지 않은 키” → “startup 실패” → “서버 종료”로 바로 연결
S3 키가 잘못되면 서버가 무조건 꺼져야하는 건 아니기 때문에, 굳이 넣어야할 이유가 없고 운영 편의를 위해 제외를 시킴.